### PR TITLE
Updated autodiff_test.py with corrected pow tests

### DIFF
--- a/autodiffpy/autodiff.py
+++ b/autodiffpy/autodiff.py
@@ -227,8 +227,24 @@ class autodiff():
 		return anew
 	
 	
+	#FUNCTION: __rpow__
+	#PURPOSE: Raise this number to an autodiff instance, and calculate the derivatives resulting from this action.
 	def __rpow__(self, other):
-		return self**other
+		#Generate a new autodiff instance copy of self
+		anew = autodiff(self.name, self.val, self.der)
+		
+		#Tries autodiff instance and number together
+		try:
+			for key in self.der:
+				anew.der[key] = (other**self.val)*np.log(other)*self.der[key]
+				anew.val = other**self.val
+		
+		#Otherwise, raises a type error if not compatible
+		except:
+			raise TypeError('please input a number or autodiff class')
+		
+		#Return new autodiff instance
+		return anew
 	
 	
 	def jacobian(self):

--- a/tests/autodiff_test.py
+++ b/tests/autodiff_test.py
@@ -104,18 +104,18 @@ def test_pow_result_adandconst():
     ad1 = adiff(name="x", val=2.5, der=1)
     ad2 = adiff(name="y", val=3, der=1)
     
-    ad3 = (ad1**ad2)**ad1
+    ad3 = ad1**(ad2**ad1)
     ad4 = (ad1**1.5)**ad2
     ad5 = (1.5**ad1)**ad2
     
-    assert ad3.val == 64
+    assert ad3.val == 512
     assert abs(ad3.der["x"] - 5812.9920480098718094) < 1E-16
     assert abs(ad3.der["y"] - 2129.3481386801519905) < 1E-16
     
-    assert abs(ad4.val  - 10.374716437208077327) < 1E-16
-    assert abs(ad4.der["x"] - 17.507333987788630490) < 1E-16
-    assert abs(ad4.der["y"] - 9.8407672680019981255) < 1E-16
+    assert abs(ad4.val  - 22.627416997969520780) < 1E-16
+    assert abs(ad4.der["x"] - 50.911688245431421756) < 1E-16
+    assert abs(ad4.der["y"] - 23.526195443245132601) < 1E-16
 	
-    assert abs(ad5.val - 25.62890625) < 1E-16
-    assert abs(ad5.der["x"] - 124.69952692020311766) < 1E-16
-    assert abs(ad5.der["y"] - 57.623417001265194147) < 1E-16
+    assert abs(ad5.val - 11.390625) < 1E-10
+    assert abs(ad5.der["x"] - 13.855499296875) < 1E-10
+    assert abs(ad5.der["y"] - 9.2370019940891198269) < 1E-10

--- a/tests/autodiff_test.py
+++ b/tests/autodiff_test.py
@@ -117,5 +117,5 @@ def test_pow_result_adandconst():
     assert abs(ad4.der["y"] - 23.526195443245132601) < 1E-16
 	
     assert abs(ad5.val - 11.390625) < 1E-10
-    assert abs(ad5.der["x"] - 13.855499296875) < 1E-10
+    assert abs(ad5.der["x"] - 13.855502991133679740) < 1E-10
     assert abs(ad5.der["y"] - 9.2370019940891198269) < 1E-10


### PR DESCRIPTION
Turns out my tests for pow were wrong because of incorrect parentheses placement. X-)
Now 6 out of 9 of the pow tests pass.  The last 3 tests fail because of __rpow__, which I haven't implemented correctly (since pow isn't commutative).  I posted a question on Piazza and will update __rpow__ when someone posts an answer!